### PR TITLE
Fix build with GCC 4.9.4

### DIFF
--- a/teeterm.c
+++ b/teeterm.c
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
 		return 1;
 	}
 	
-	for (int i = 0; i <= 1; ++i) {
+	for (i = 0; i <= 1; ++i) {
 		strcpy(ptyNames[i], "pty");
 		if (customname) {
 			strcat(ptyNames[i], argv[2]);


### PR DESCRIPTION
`for` loop iterator variables must be declared outside of the loop header in C89. Tested and confirmed to fix build with GCC 4.9.4 on Ubuntu 14.04.6.